### PR TITLE
Use referer to autodetect home instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+lmmy.db
+*.tmp

--- a/lmmy.py
+++ b/lmmy.py
@@ -105,6 +105,8 @@ class WelcomeHandler(RequestHandler):
 
 class CommunityHandler(RequestHandler):
 	async def get(self, name, domain):
+		name = name.rstrip('/')
+
 		if not self.db.has_instance(domain):
 			return self.redirect(f"/err")
 
@@ -147,7 +149,7 @@ async def main():
 	app = tornado.web.Application([
 		(r"/", tornado.web.RedirectHandler, { 'url': 'https://join-lemmy.org/' }),
 		(r"/welcome", WelcomeHandler, { 'db': db }),
-		(r"/c/([\w.]+)@([a-zA-Z0-9._:-]+)", CommunityHandler, { 'db': db }),
+		(r"/c/([\w.]+)@([a-zA-Z0-9._:-]+)/?", CommunityHandler, { 'db': db }),
 		(r"/error", ErrorHandler, { 'db': db })
 	])
 	app.listen(8888)


### PR DESCRIPTION
Added code to use the `Referer` header (when available) to automatically set the user's home instance, otherwise they'll be taken to the usual welcome page.

Also handling for trailing slashes in community names

Resolves #1 